### PR TITLE
Remove Retry-After from synthetic responses

### DIFF
--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -26,6 +26,10 @@ sub vcl_error {
     if (obj.status == 200) {
         set obj.http.content-type = table.lookup(contentType, req.url.path);
         synthetic table.lookup(routes, req.url.path);
+
+        // When using vcl_error for a synthetic response, Varnish adds a Retry-After header to the response that isn't correct.
+        unset obj.http.Retry-After;
+
         return (deliver);
     }
 }

--- a/vcl/main.vcl
+++ b/vcl/main.vcl
@@ -30,6 +30,15 @@ sub vcl_error {
         // When using vcl_error for a synthetic response, Varnish adds a Retry-After header to the response that isn't correct.
         unset obj.http.Retry-After;
 
+        // Clean up standard response headers.
+        if (!req.http.Fastly-Debug) {
+            unset obj.http.Server;
+            unset obj.http.Via;
+            unset obj.http.X-Cache-Hits;
+            unset obj.http.X-Cache;
+            unset obj.http.X-Served-By;
+        }
+
         return (deliver);
     }
 }


### PR DESCRIPTION
Resolves #1, #2, #3, and #4.

It looks like Varnish adds a `Retry-After` header if `error` is used in the `vcl_recv` to jump to `vcl_error`. Presumable because it's likely to serve a 503 response that a user agent could retry. This isn't valid/useful for a 200 response.

Hides the informational response headers unless the request contains the `Fastly-Debug` header.